### PR TITLE
iPad, Mentor Panel, Barnhill thumbnail image displays as blank rectangle

### DIFF
--- a/client/src/components/video-thumbnail.jsx
+++ b/client/src/components/video-thumbnail.jsx
@@ -43,7 +43,7 @@ const VideoThumbnail = ({ mentor, isMobile, width, height }) => {
       playing={isPlaying}
       volume={0.0}
       muted
-      controls={false}
+      controls={isPlaying}
       playsinline
       webkit-playsinline="true"
     />


### PR DESCRIPTION
Fix: user can click panel to load image